### PR TITLE
Add coreutils-base64 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,11 +111,12 @@ then
 
 	AC_ARG_ENABLE([base64decoder],
 		[AS_HELP_STRING([--enable-base64decoder],
-			[base64decoder, openssl or uudecode (default=openssl)]
+			[base64decoder, openssl or coreutils or uudecode (default=openssl)]
 		)],
 		[   case "${enableval}" in
 			openssl)    BASE64DECODER=openssl;;
 			uudecode)   BASE64DECODER=uudecode;;
+			coreutils)  BASE64DECODER=coreutils;;
 			*)          AC_MSG_ERROR(bad value ${enableval} for --enable-base64decoder) ;;
 			esac
 		],
@@ -136,6 +137,10 @@ then
 	CFLAGS="${CFLAGS} -DBASE64_DECODER_UUDECODE "
 	fi
 
+	if test "$BASE64DECODER" == "coreutils"
+	then
+	CFLAGS="${CFLAGS} -DBASE64_DECODER_COREUTILS "
+	fi
 
 	# Checks for header files.
 	AC_CHECK_HEADERS([sys/syscall.h wordexp.h])

--- a/utils.c
+++ b/utils.c
@@ -44,6 +44,8 @@ int Execute(const char *Cmd)
 	#endif /* BASE64_DECODER_OPENSSL */
 	#ifdef BASE64_DECODER_UUDECODE
 	#endif /* BASE64_DECODER_UUDECODE */
+	#ifdef BASE64_DECODER_COREUTILS
+	#endif /* BASE64_DECODER_COREUTILS */
 
 	#ifdef HAVE_WORDEXP
 		#include <wordexp.h>
@@ -385,6 +387,40 @@ int	Base64Decode(const char *File)
 
 	return 0;
 #endif /* BASE64_DECODER_UUDECODE */
+#ifdef BASE64_DECODER_COREUTILS
+	char Cmd[2048];
+	FILE *fp;
+
+	sprintf(Cmd, "%s.base64", File);
+
+	fp = fopen(Cmd, "w");
+	if( fp == NULL )
+	{
+		return -1;
+	}
+
+	fclose(fp);
+
+	sprintf(Cmd, "cat %s >> %s.base64", File, File);
+
+	if( Execute(Cmd) != 0 )
+	{
+		return -1;
+	}
+
+	sprintf(Cmd, "rm %s", File);
+
+	if( Execute(Cmd) != 0 )
+	{
+		return -1;
+	}
+
+	sprintf(Cmd, "base64 -d %s.base64 > %s", File, File);
+
+	Execute(Cmd);
+
+	return 0;
+#endif /* BASE64_DECODER_COREUTILS */
 #endif /* WIN32 */
 }
 


### PR DESCRIPTION
Enable base64 command (part of GNU CoreUtils), especially useful on openwrt, because coreutils-base64 is included in openwrt's packages repo and only take 20KB which far less than libopenssl and uudecode is disabled on openwrt's busybox. 

Tested working in OpenWRT BB:
~~~
root@OpenWrt:~# /tmp/dnsforwarder -f /tmp/dnsforwarder.config
DNSforwarder by holmium. Version 5.0.15 . License : GPL v3.
Time of compilation : Mar 15 2015 01:24:36.

Please run `dnsforwarder -p' if something wrong.

Configure File : /tmp/dnsforwarder.config


Local working interface:0.0.0.0
Local working port:5353
Local TCP is opened:Yes
Primary server:UDP
TCP Server:8.8.4.4
TCP Server:8.8.8.8
TCP Server:208.67.222.222
UDP Server:114.114.114.114
UDP Server:114.114.115.115
UDP Server:8.8.8.8
UDP Parallel Query:Yes
UDP Anti-pollution:Yes
Use cache:Yes
Memory Cache:Yes
Ignore TTL:No
GFW List:http://autoproxy-gfwlist.googlecode.com/svn/trunk/gfwlist.txt

[INFO] Excluded & Disabled list initialized.
[INFO] Loading the existing GFW List ...
[INFO] Loading the existing GFW List completed. 2573 effective items.
[INFO] UDP socket 0.0.0.0:5353 created.
[INFO] TCP socket 0.0.0.0:5353 created.
[INFO] Now you can set DNS.
[INFO] Loading GFW List From http://autoproxy-gfwlist.googlecode.com/svn/trunk/gfwlist.txt ...
[INFO] GFW List saved at /tmp/gfwlist.txt.
[INFO] Loading GFW List completed. 2573 effective items.
~~~