### PR TITLE
make stable hashtable expansion

### DIFF
--- a/default.config
+++ b/default.config
@@ -90,6 +90,7 @@ TCPGroup
 # 从文件加载服务器组 (since 6.1.3)
 # 服务器组文件的写法请参阅：https://github.com/holmium/dnsforwarder/wiki/GroupFile-%E7%9A%84%E5%86%99%E6%B3%95-%7C-How-to-write-GroupFiles
 # 可以有多条 `GroupFile' 选项
+# 后面的规则优先于前面的返回
 #
 # 示例一：
 #  GroupFile D:\group.txt

--- a/default.en.config
+++ b/default.en.config
@@ -113,6 +113,7 @@ TCPGroup
 #     you can write the corresponding rules in a file and import here with this option (since 6.1.3)
 # Please consult the following page for the details:https://github.com/holmium/dnsforwarder/wiki/GroupFile-%E7%9A%84%E5%86%99%E6%B3%95-%7C-How-to-write-GroupFiles
 # Multiple `GroupFile' statements are allowed
+# The last rule matches first
 #
 # Example 1:
 #  GroupFile D:\group.txt


### PR DESCRIPTION
Regenerate slots basing on the array of stored nodes.

Sorting makes the top node of a linked list down in a new slot. It leads
to random node order after expansions, especially for the same hash but
different nodes. Here, for example: 2+ rules for a same domain as nodes,
any one could be on the top.